### PR TITLE
signer: add convenience method for creating a signer given an already built etree.Document

### DIFF
--- a/signer.go
+++ b/signer.go
@@ -52,6 +52,11 @@ func NewSigner(xml string) (*Signer, error) {
 	if err != nil {
 		return nil, err
 	}
+	return NewSignerFromDoc(doc)
+}
+
+// NewSignerFromDoc returns a *Signer for the Document provided
+func NewSignerFromDoc(doc *etree.Document) (*Signer, error) {
 	s := &Signer{signatureData: signatureData{xml: doc}}
 	return s, nil
 }


### PR DESCRIPTION
Currently the signer creation requires the XML being provided as string. Then, internally it is converted to a Document. Some use cases already uses etree.Document so the signer creation forces it to be converted to string prior to be converted back to etree.Document.

This PR add a new convenience method so that the signer can consume an existing etree.Document.
