### PR TITLE
fix: support Signature element on the root level

### DIFF
--- a/signedxml.go
+++ b/signedxml.go
@@ -112,7 +112,7 @@ func (s *signatureData) SetSignature(sig string) error {
 }
 
 func (s *signatureData) parseEnvelopedSignature() error {
-	sig := s.xml.FindElement(".//Signature")
+	sig := s.xml.FindElement("//Signature")
 	if sig != nil {
 		s.signature = sig
 	} else {

--- a/testdata/root-level-signature.xml
+++ b/testdata/root-level-signature.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Signature xmlns="http://www.w3.org/2000/09/xmldsig#">
+    <SignedInfo>
+        <CanonicalizationMethod Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"></CanonicalizationMethod>
+        <SignatureMethod Algorithm="http://www.w3.org/2000/09/xmldsig#rsa-sha1"></SignatureMethod>
+        <Reference URI="#test">
+            <DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"></DigestMethod>
+            <Transforms>
+                <Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"></Transform>
+            </Transforms>
+            <DigestValue></DigestValue>
+        </Reference>
+    </SignedInfo>
+    <SignatureValue></SignatureValue>
+    <KeyInfo>
+        <X509Data>
+            <X509Certificate>testtest</X509Certificate>
+        </X509Data>
+    </KeyInfo>
+    <Object xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Id="test">
+      <Foo>name</Foo>
+    </Object>
+</Signature>


### PR DESCRIPTION
This PR contains support for selecting Signature elements that are a root level element. 

<details>
<summary>Signed XML Example</summary>

```xml
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
<Signature xmlns="http://www.w3.org/2000/09/xmldsig#">
    <SignedInfo xmlns="http://www.w3.org/2000/09/xmldsig#">
        <CanonicalizationMethod Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"/>
        <SignatureMethod Algorithm="http://www.w3.org/2000/09/xmldsig#rsa-sha1"/>
        <Reference URI="#test">
            <DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/>
            <Transforms>
                <Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
            </Transforms>
            <DigestValue>uTkKWNbF/FYTlRQPbSwW27afYnw=</DigestValue>
        </Reference>
    </SignedInfo>
    <SignatureValue>G1/jIIkOnkylVt1ddan9qC08u2Nlp1pu3NqhEYn4wr2QQpsIfn6ZnSdYHVAutt0fTkaAHi+h3dOdIJ1FpMsEY0OopDlbmvQQbEVe5wAfmRII/wXyzDCjTi+6apKmnaWhPlNwh7TxeYltTN32mOInpIUqEMcFn5C5Vkiwklok2fmbrGh4ENtGi/3vhlUmiCIoKW+VisYwGmphon+2Erdj5Lheq/mgja98uOrjZpRGv3oJ3iUn/ye8568Uv10xYMynSxMxth0PGy2kK2IyixSISO+bQGRDrLctqbZRDu+q/P4UXhvuFjh1LcNW7+n9YaAfqOI16l6zaZGA04mZSPfSpI2eiJxUKEOo+pizY2QYR0X8NozKDW7mBCTM6wdJwiKufOeu+nfvYJbEfMnru+dNZhi8Y1wTqf358CcNtjRzhc7rZYciyP/CC8v6BNXyMYhnNv6I/5ULTFVO+IDqwqbsJzC6NVvS6JjtCeYdNoQowXLO0TLslgbtnQWRMMFSmqRXGhzgThId5sDE6teScVz42lJIVr/B3soARoHBOJGy4AjVYLAqbMy8eLOUSG/C0SJWrHysnfpQr8wobaUEpzXi1j7YMORnMaK5vCJdVAByK5h98MwdRmRgpTh4HMjSNP8TDng2mw9+BoMrnwL6QUNKsGT8imY0WMfFI6LBZqIqN54=</SignatureValue>
    <KeyInfo>
        <X509Data>
            <X509Certificate>testtest</X509Certificate>
        </X509Data>
    </KeyInfo>
    <Object xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Id="test">
      <Foo>name</Foo>
    </Object>
</Signature>
```

</details>

Issues: https://github.com/moov-io/signedxml/issues/47 