### PR TITLE
removed XML declaration before signature operations

### DIFF
--- a/signedxml.go
+++ b/signedxml.go
@@ -345,14 +345,14 @@ func removeXMLDeclaration(doc *etree.Document) {
 	for _, t := range doc.Child {
 		if p, ok := t.(*etree.ProcInst); ok && p.Target == "xml" {
 			doc.RemoveChild(p)
-
-			// Remove CharData right after removing the XML declaration
-			for _, t2 := range doc.Child {
-				if p2, ok := t2.(*etree.CharData); ok {
-					doc.RemoveChild(p2)
-				}
-			}
 			break
+		}
+	}
+
+	// Remove CharData right after removing the XML declaration
+	for _, t2 := range doc.Child {
+		if p2, ok := t2.(*etree.CharData); ok {
+			doc.RemoveChild(p2)
 		}
 	}
 }

--- a/signedxml.go
+++ b/signedxml.go
@@ -345,6 +345,13 @@ func removeXMLDeclaration(doc *etree.Document) {
 	for _, t := range doc.Child {
 		if p, ok := t.(*etree.ProcInst); ok && p.Target == "xml" {
 			doc.RemoveChild(p)
+
+			// Remove CharData right after removing the XML declaration
+			for _, t2 := range doc.Child {
+				if p2, ok := t2.(*etree.CharData); ok {
+					doc.RemoveChild(p2)
+				}
+			}
 			break
 		}
 	}

--- a/signedxml.go
+++ b/signedxml.go
@@ -339,3 +339,26 @@ func calculateHash(reference *etree.Element, doc *etree.Document) (string, error
 
 	return calculatedValue, nil
 }
+
+// removeXMLDeclaration searches for and removes the XML declaration processing instruction.
+func removeXMLDeclaration(doc *etree.Document) {
+	for _, t := range doc.Child {
+		if p, ok := t.(*etree.ProcInst); ok && p.Target == "xml" {
+			doc.RemoveChild(p)
+			break
+		}
+	}
+}
+
+// parseXML parses an XML string into an etree.Document and removes the XML declaration if present.
+func parseXML(xml string) (*etree.Document, error) {
+	doc := etree.NewDocument()
+	if err := doc.ReadFromString(xml); err != nil {
+		return nil, err
+	}
+
+	doc.ReadSettings.PreserveCData = true
+	removeXMLDeclaration(doc)
+
+	return doc, nil
+}

--- a/signedxml_test.go
+++ b/signedxml_test.go
@@ -50,6 +50,13 @@ func TestSignatureLogicWithCLibXMLSec(t *testing.T) {
 			Convey("And signature digest should match with signature generated generated using xmlsec", func() {
 				So(generatedDigestValue.Text(), ShouldEqual, digestValueElement.Text())
 			})
+			Convey("And signature generated using xmlsec should be valid", func() {
+				validator, _ := NewValidator(string(xmlGeneratedSign))
+				validator.Certificates = append(validator.Certificates, *cert)
+				refs, err := validator.ValidateReferences()
+				So(err, ShouldBeNil)
+				So(len(refs), ShouldEqual, 1)
+			})
 		})
 	})
 }

--- a/signer.go
+++ b/signer.go
@@ -46,9 +46,7 @@ type Signer struct {
 
 // NewSigner returns a *Signer for the XML provided
 func NewSigner(xml string) (*Signer, error) {
-	doc := etree.NewDocument()
-	doc.ReadSettings.PreserveCData = true
-	err := doc.ReadFromString(xml)
+	doc, err := parseXML(xml)
 	if err != nil {
 		return nil, err
 	}

--- a/testdata/doc.xml
+++ b/testdata/doc.xml
@@ -1,0 +1,33 @@
+<References>
+<Book>
+    <Author>
+        <FirstName>Bruce</FirstName>
+        <LastName>Schneier</LastName>
+    </Author>
+    <Title>Applied Cryptography</Title>
+    </Book>
+    <Web>
+    <Title>XMLSec</Title>
+        <Url>http://www.aleksey.com/xmlsec/</Url>
+    </Web>
+  <Signature xmlns="http://www.w3.org/2000/09/xmldsig#">
+      <SignedInfo xmlns="http://www.w3.org/2000/09/xmldsig#">
+          <CanonicalizationMethod Algorithm=
+    "http://www.w3.org/TR/2001/REC-xml-c14n-20010315"/>
+          <SignatureMethod Algorithm=
+    "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>
+          <Reference URI="">
+              <Transforms>
+                  <Transform Algorithm=
+       "http://www.w3.org/2000/09/xmldsig#enveloped-signature" />
+              </Transforms>
+              <DigestMethod Algorithm=
+        "http://www.w3.org/2001/04/xmlenc#sha256"/>
+              <DigestValue></DigestValue>
+          </Reference>
+      </SignedInfo>
+      <SignatureValue />
+      <KeyInfo>
+      </KeyInfo>
+  </Signature>
+</References>

--- a/testdata/signature-generate-using-xmlseclib.xml
+++ b/testdata/signature-generate-using-xmlseclib.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0"?>
+<References>
+<Book>
+    <Author>
+        <FirstName>Bruce</FirstName>
+        <LastName>Schneier</LastName>
+    </Author>
+    <Title>Applied Cryptography</Title>
+    </Book>
+    <Web>
+    <Title>XMLSec</Title>
+        <Url>http://www.aleksey.com/xmlsec/</Url>
+    </Web>
+  <Signature xmlns="http://www.w3.org/2000/09/xmldsig#">
+      <SignedInfo xmlns="http://www.w3.org/2000/09/xmldsig#">
+          <CanonicalizationMethod Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"/>
+          <SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>
+          <Reference URI="">
+              <Transforms>
+                  <Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
+              </Transforms>
+              <DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
+              <DigestValue>kXaaD5Gor8lfNc6eYV31AyF0ekT9H/YY28Oh665mooQ=</DigestValue>
+          </Reference>
+      </SignedInfo>
+      <SignatureValue>Z81G62a0rLOLlgOQyJJN5amwIQ9Wu3vqoCc5CDp8wHz8xVHBGv6MOcaXtzkXOveQ
+KFRuFsxWtlNdxyUyfHzkwHk1BLfzUNbG1BNNjgktJ63leO5w3C4v64/3/HnIPEq1
+eE1uSMO0HDevDrgethWofa2ExxBG2CU8bY4pGzLx95uhBUxk5ilkR1P4tayJp1Va
+U0/roVBZTo8WH+ol15hj5FFV4rjTMPV2kPy9geNsMDZi+N30C/RNHB7n5MScnBC+
+OiCMRmJEcgJpA8/GXCX+y7WFKsVB9p6VO5euC8UUD9dvezvHhMDBwqncjvbnvjOk
+BD58sY6v8LpLIabJUmg3Yt6YjU8dToxv36QrIjsN/m1p5sCsWIMWCdW9MtsR0VGl
+MjkBCQUE70aCUzVbNrtJZaGY+YH9oDvHsLHKzTZusOvYLGCtKwaBcqVEuad/7Nvs
+e7JjYVl6HfyHWZPY6PDt0Q180f+U9QV2C1EdI+r2sbMd+HMft2Jp6Wii3mHZD6hy
+jFr54lztG0x9/X75jwBIaoMv8RtTl8lKfFpBiUc9UrpxKJBOOhMPWiYdwrrAzE1g
+NEHZvU3wbZiFWCAo+4RtCB++pWnoEJ16tuGHKlEIWTJRAnqm4ld1hX0zo7ZVkabD
+ixthaEIn8XmlaL92X5ZAI0P+yFC5kXSDKtLVnf6TgfE=</SignatureValue>
+      <KeyInfo>
+      </KeyInfo>
+  </Signature>
+</References>

--- a/validator.go
+++ b/validator.go
@@ -19,8 +19,7 @@ type Validator struct {
 
 // NewValidator returns a *Validator for the XML provided
 func NewValidator(xml string) (*Validator, error) {
-	doc := etree.NewDocument()
-	err := doc.ReadFromString(xml)
+	doc, err := parseXML(xml)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### Overview/Description
In this merge request, I have implemented a change to the process of generating and validating XML signatures. Specifically, I've removed the XML declaration from documents before these cryptographic operations are performed.

### Why the Change Was Necessary
The presence of an XML declaration was found to potentially affect the consistency of the signature generation and validation processes. Differences in the XML prolog presence could lead to mismatches in signature validation, which in turn could compromise the integrity and reliability of the system.

### What Was Changed
- **XML Parsing Adjustment**: The code now systematically removes the XML declaration from the document before any signature-related processing occurs. This ensures that the XML content fed into the signing and validation processes is consistent, regardless of its original state.
- **Code Refactoring**: Minor refactoring was done to enhance the clarity and efficiency of the signature processing functions, aligning with best practices for XML manipulation.

### Impact of the Change
This change standardizes how XML documents are handled, removing potential discrepancies that could arise from varying XML prolog presence. As a result, the system's cryptographic operations are now more robust and less prone to errors related to XML formatting differences.

### Additional Notes
- **Testing**: tests were added to validate xml signature digest with signature digest generate using xmlsec
