### PR TITLE
test(fuzz): add Validator fuzzer seeded from testdata XML

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,0 +1,39 @@
+name: Go Fuzz Testing
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
+
+permissions:
+  contents: read
+
+jobs:
+  fuzz:
+    name: Fuzz
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        command:
+          - "go test . -fuzz FuzzValidator -fuzztime 10m"
+
+    steps:
+    - name: Set up Go 1.x
+      uses: actions/setup-go@v7
+      with:
+        go-version: stable
+      id: go
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v7
+      with:
+        fetch-depth: 0
+
+    - name: Fuzz
+      run: ${{ matrix.command }}
+
+    - name: Report Failures
+      if: ${{ failure() }}
+      run: |
+        find . -path '*/testdata/fuzz/*' -type f 2>/dev/null | xargs -r -n1 tail -n +1 -v || true

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -1,0 +1,53 @@
+package signedxml_test
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/moov-io/signedxml"
+)
+
+func FuzzValidator(f *testing.F) {
+	populateCorpus(f)
+
+	f.Fuzz(func(t *testing.T, contents string) {
+		if len(contents) > 1<<20 {
+			t.Skip()
+		}
+
+		v, err := signedxml.NewValidator(contents)
+		if err != nil || v == nil {
+			return
+		}
+		_, _ = v.ValidateReferences()
+		_ = v.SigningCert()
+	})
+}
+
+func populateCorpus(f *testing.F) {
+	f.Helper()
+
+	f.Add("")
+	f.Add("<root></root>")
+	f.Add("<?xml version=\"1.0\"?><foo/>")
+
+	roots := []string{"testdata", filepath.Join("tests", "testdata"), "examples"}
+	for _, root := range roots {
+		_ = filepath.Walk(root, func(path string, info fs.FileInfo, err error) error {
+			if err != nil || info == nil || info.IsDir() {
+				return nil
+			}
+			if strings.HasSuffix(strings.ToLower(path), ".xml") {
+				bs, err := os.ReadFile(path)
+				if err != nil || len(bs) > 512*1024 {
+					return nil
+				}
+				f.Add(string(bs))
+			}
+			return nil
+		})
+	}
+}


### PR DESCRIPTION
## Summary
Add a native Go fuzzer for `signedxml.NewValidator` / `ValidateReferences` using XML samples under `testdata`, `tests/testdata`, and `examples`.

## Test plan
- [x] `go test` for affected packages
- [x] `go test -run='^$' -fuzz=FuzzValidator -fuzztime=3s` smoke