### PR TITLE
Add zizmor GitHub Actions security analysis

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,16 @@
+# Use https://app.stepsecurity.io/ to improve workflow security
+name: zizmor
+
+on:
+  push:
+  pull_request:
+
+permissions: {}
+
+jobs:
+  zizmor:
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+    uses: moov-io/.github/.github/workflows/zizmor.yml@768836368a4ebdf0959c6497d41433e7193103cc


### PR DESCRIPTION
Adds a thin caller that runs zizmor on every push and pull request via moov-io/.github. Findings upload to code scanning and do not fail CI.