### PR TITLE
Look up signature references by ID, Id, or id

### DIFF
--- a/signedxml.go
+++ b/signedxml.go
@@ -281,12 +281,16 @@ func (s *signatureData) findReferencedElement(reference *etree.Element, inputDoc
 		return inputDoc.Root(), nil
 	}
 
-	refIDAttribute := "ID"
+	// Try the common XML ID attribute casings used in signatures.
+	// SetReferenceIDAttribute overrides the list when callers need a custom name.
+	attrs := []string{"ID", "Id", "id"}
 	if s.refIDAttribute != "" {
-		refIDAttribute = s.refIDAttribute
+		attrs = []string{s.refIDAttribute}
 	}
-	if e := findElementByAttr(inputDoc.Root(), refIDAttribute, uri); e != nil {
-		return e, nil
+	for _, attr := range attrs {
+		if e := findElementByAttr(inputDoc.Root(), attr, uri); e != nil {
+			return e, nil
+		}
 	}
 
 	// SAML v1.1 Assertions use AssertionID

--- a/signedxml_test.go
+++ b/signedxml_test.go
@@ -519,6 +519,36 @@ func TestReferenceURIWithQuoteDoesNotPanic(t *testing.T) {
 	}
 }
 
+func TestFindReferencedElementIDCasings(t *testing.T) {
+	cases := []struct {
+		name string
+		xml  string
+		attr string
+	}{
+		{name: "ID", xml: `<root><item ID="abc">x</item></root>`, attr: "ID"},
+		{name: "Id", xml: `<root><item Id="abc">x</item></root>`, attr: "Id"},
+		{name: "id", xml: `<root><item id="abc">x</item></root>`, attr: "id"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			doc := etree.NewDocument()
+			if err := doc.ReadFromString(tc.xml); err != nil {
+				t.Fatal(err)
+			}
+			ref := etree.NewElement("Reference")
+			ref.CreateAttr("URI", "#abc")
+			s := &signatureData{xml: doc}
+			elem, err := s.findReferencedElement(ref, doc)
+			if err != nil {
+				t.Fatalf("expected to find %s: %v", tc.attr, err)
+			}
+			if elem.SelectAttrValue(tc.attr, "") != "abc" {
+				t.Fatalf("unexpected element: %#v", elem)
+			}
+		})
+	}
+}
+
 func TestValidatorQuotedReferenceURI(t *testing.T) {
 	xml, err := os.ReadFile("./testdata/bbauth-metadata.xml")
 	if err != nil {


### PR DESCRIPTION
## What

`findReferencedElement` only searched `ID` (plus SAML `AssertionID`). Many XML signatures use `Id` or `id` instead, so those references failed to resolve.

This tries `ID`, `Id`, and `id` unless the caller set a custom attribute with `SetReferenceIDAttribute`.

## Source

- [daugminas/signedxml@1c2adca](https://github.com/daugminas/signedxml/commit/1c2adca6be3017e783ef60b9849081a6bf09032d) — **daugminas**
- Related earlier change: [monzo/signedxml@f68015c](https://github.com/monzo/signedxml/commit/f68015c158e38d0b99bc09d890f761d1e0677b55) — Emily Ekberg

The original daugminas patch used etree path interpolation, which we already replaced after a quote-in-URI panic. This ports the casing list onto the current attribute walker.

## Tests

`go test ./...` passes, including a new casing table test.