### PR TITLE
Add helpers to insert XML or text into a signature template

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -1,0 +1,89 @@
+package signedxml
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+
+	"github.com/beevik/etree"
+)
+
+// InsertXMLintoSignatureTemplate inserts xmlToBeInserted as a child of the
+// first <Object> in xmlSignatureTemplate. No transforms are applied.
+func InsertXMLintoSignatureTemplate(xmlSignatureTemplate, xmlToBeInserted string, unindent, addProcessInstructions bool) (string, error) {
+	if xmlSignatureTemplate == "" || xmlToBeInserted == "" {
+		return "", nil
+	}
+
+	sigDoc := etree.NewDocument()
+	if addProcessInstructions {
+		sigDoc.CreateProcInst("xml", `version="1.0" encoding="UTF-8"`)
+	}
+	if err := sigDoc.ReadFromString(xmlSignatureTemplate); err != nil {
+		return "", err
+	}
+	sig := sigDoc.Root()
+	if sig == nil || sig.Tag != "Signature" {
+		return "", errors.New("no root tag present in xmlSignatureTemplate or its root tag is not `Signature`")
+	}
+	obj := sig.FindElement(".//Object")
+	if obj == nil {
+		return "", errors.New("no 'Object' tag found in xmlSignatureTemplate, can't insert xmlToBeInserted")
+	}
+
+	sigTargetDoc := etree.NewDocument()
+	if err := sigTargetDoc.ReadFromString(xmlToBeInserted); err != nil {
+		return "", err
+	}
+	sigTarget := sigTargetDoc.Root()
+	if sigTarget == nil {
+		return "", errors.New("can't set root of the 'xmlToBeInserted' document")
+	}
+
+	obj.AddChild(sigTarget)
+	if unindent {
+		sigDoc.Unindent()
+	}
+	return sigDoc.WriteToString()
+}
+
+// InsertTextIntoSignatureTemplate sets the first <Object> text to the given value.
+func InsertTextIntoSignatureTemplate(xmlSignatureTemplate, text string, unindent, addProcessInstructions bool) (string, error) {
+	if xmlSignatureTemplate == "" || text == "" {
+		return "", nil
+	}
+
+	sigDoc := etree.NewDocument()
+	if addProcessInstructions {
+		sigDoc.CreateProcInst("xml", `version="1.0" encoding="UTF-8"`)
+	}
+	if err := sigDoc.ReadFromString(xmlSignatureTemplate); err != nil {
+		return "", err
+	}
+	sig := sigDoc.Root()
+	if sig == nil || sig.Tag != "Signature" {
+		return "", errors.New("no root tag present in xmlSignatureTemplate or its root tag is not `Signature`")
+	}
+	obj := sig.FindElement(".//Object")
+	if obj == nil {
+		return "", errors.New("no 'Object' tag found in xmlSignatureTemplate, can't insert xmlToBeInserted")
+	}
+
+	obj.SetText(text)
+	if unindent {
+		sigDoc.Unindent()
+	}
+	return sigDoc.WriteToString()
+}
+
+// PrepPKCS8PrivateKey decodes PEM-encoded PKCS #8 private key bytes for Signer.Sign.
+func PrepPKCS8PrivateKey(PEMKeyBytes []byte) (any, error) {
+	if PEMKeyBytes == nil {
+		return nil, errors.New("no private key bytes provided")
+	}
+	pemBlock, _ := pem.Decode(PEMKeyBytes)
+	if pemBlock == nil {
+		return nil, errors.New("failed to decode PEM private key")
+	}
+	return x509.ParsePKCS8PrivateKey(pemBlock.Bytes)
+}

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -1,0 +1,36 @@
+package signedxml
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestInsertXMLintoSignatureTemplate(t *testing.T) {
+	tmpl := `<Signature xmlns="http://www.w3.org/2000/09/xmldsig#"><Object></Object></Signature>`
+	doc := `<payload id="1">hello</payload>`
+	out, err := InsertXMLintoSignatureTemplate(tmpl, doc, true, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "<payload id=\"1\">hello</payload>") {
+		t.Fatalf("inserted XML missing: %s", out)
+	}
+}
+
+func TestInsertTextIntoSignatureTemplate(t *testing.T) {
+	tmpl := `<Signature xmlns="http://www.w3.org/2000/09/xmldsig#"><Object></Object></Signature>`
+	out, err := InsertTextIntoSignatureTemplate(tmpl, "plain-text", true, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "plain-text") {
+		t.Fatalf("inserted text missing: %s", out)
+	}
+}
+
+func TestInsertXMLintoSignatureTemplateMissingObject(t *testing.T) {
+	_, err := InsertXMLintoSignatureTemplate(`<Signature></Signature>`, `<a/>`, false, false)
+	if err == nil {
+		t.Fatal("expected error when Object is missing")
+	}
+}


### PR DESCRIPTION
## What

Adds convenience helpers for assembling enveloped signatures:

- `InsertXMLintoSignatureTemplate` — nest a document under the first `<Object>`
- `InsertTextIntoSignatureTemplate` — set that object's text
- `PrepPKCS8PrivateKey` — decode a PEM PKCS #8 key for `Signer.Sign`

## Source

Cherry-picked from **daugminas**:

- [daugminas/signedxml@4f7152f](https://github.com/daugminas/signedxml/commit/4f7152fd82ef9b35fbbf0d198eec166a892179a1)
- [daugminas/signedxml@cf137e6](https://github.com/daugminas/signedxml/commit/cf137e68ae252dccb98b13072bbbcdbe5517d0ee)

Comments were translated to English to match the rest of the package. `PrepPKCS8PrivateKey` now errors on invalid PEM instead of panicking.

## Tests

`go test .` passes.