### PR TITLE
ci: pin Actions and tighten workflow permissions

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -20,14 +20,15 @@ jobs:
 
     steps:
     - name: Set up Go 1.x
-      uses: actions/setup-go@v7
+      uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
       with:
         go-version: stable
       id: go
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v7
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
+        persist-credentials: false
         fetch-depth: 0
 
     - name: Fuzz

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ master ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Go Build (CGO)
@@ -15,13 +18,15 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
     - name: Set up Go 1.x
-      uses: actions/setup-go@v7
+      uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
       with:
         go-version: stable
       id: go
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v7
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
 
     - name: Test (Unix)
       if: runner.os != 'Windows'


### PR DESCRIPTION
## What

Fixes the open [code-scanning alerts](https://github.com/moov-io/signedxml/security/code-scanning):

| Alert | Rule | Fix |
|---|---|---|
| #5 | `zizmor/excessive-permissions` | `permissions: contents: read` on `test.yml` |
| #4, #1 | `zizmor/artipacked` | `persist-credentials: false` on `actions/checkout` |
| #2, #3, #6, #7 | `zizmor/unpinned-uses` | pin `setup-go` and `checkout` to SHAs |

- `actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e` (`v7.0.0`)
- `actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1` (`v7.0.1`)

`fuzz.yml` already had a `permissions` block. `zizmor.yml` was already pinned.